### PR TITLE
Async result consuming example

### DIFF
--- a/v4/go_async_processing/config.json
+++ b/v4/go_async_processing/config.json
@@ -1,11 +1,11 @@
 {
     "token_hmac_secret_key": "keep-it-secret",
+    "api_key": "keep-it-secret",
     "allowed_origins": [
         "http://localhost:3000"
     ],
     "proxy_rpc_endpoint": "http://localhost:3000/rpc",
     "proxy_connect_endpoint": "http://localhost:3000/connect",
-    "api_insecure": true,
     "history_size": 1,
     "history_ttl": "60s",
     "history_meta_ttl": "600s",

--- a/v4/go_async_processing/config.json
+++ b/v4/go_async_processing/config.json
@@ -1,0 +1,13 @@
+{
+    "token_hmac_secret_key": "keep-it-secret",
+    "allowed_origins": [
+        "http://localhost:3000"
+    ],
+    "proxy_rpc_endpoint": "http://localhost:3000/rpc",
+    "proxy_connect_endpoint": "http://localhost:3000/connect",
+    "api_insecure": true,
+    "history_size": 1,
+    "history_ttl": "60s",
+    "history_meta_ttl": "600s",
+    "force_recovery": true
+}

--- a/v4/go_async_processing/go.mod
+++ b/v4/go_async_processing/go.mod
@@ -1,0 +1,9 @@
+module go_async_processing
+
+go 1.19
+
+require (
+	github.com/centrifugal/gocent/v3 v3.2.0
+	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/google/uuid v1.3.0
+)

--- a/v4/go_async_processing/go.sum
+++ b/v4/go_async_processing/go.sum
@@ -1,0 +1,6 @@
+github.com/centrifugal/gocent/v3 v3.2.0 h1:s+gxnvGWKIOZYGW8SAfGUUShY0r0DuRpnKqhh3h1Ps0=
+github.com/centrifugal/gocent/v3 v3.2.0/go.mod h1:8YWDQG3sX0X1g+BaotihbhawPs6zyYGUxUEk8Ng5a2g=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/v4/go_async_processing/index.html
+++ b/v4/go_async_processing/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title></title>
+    <script type="text/javascript" src="https://unpkg.com/centrifuge@3.0.1/dist/centrifuge.js"></script>
+    <script type="text/javascript">
+        window.addEventListener('load', function () {
+            const btn = document.getElementById("btn");
+            const container = document.getElementById('messages');
+
+            const centrifuge = new Centrifuge('ws://localhost:8000/connection/websocket', {});
+
+            centrifuge.on('connecting', function (ctx) {
+                drawText('Connecting: ' + ctx.reason);
+            });
+
+            centrifuge.on('disconnected', function (ctx) {
+                drawText('Disconnected: ' + ctx.reason);
+            });
+
+            centrifuge.on('connected', function (ctx) {
+                drawText('Connected with client ID ' + ctx.client + ' over ' + ctx.transport);
+            });
+
+            // Trigger actual connection establishing with a server.
+            // At this moment actual client work starts - i.e. subscriptions
+            // defined start subscribing etc.
+            centrifuge.connect();
+
+            function drawText(text) {
+                let e = document.createElement('li');
+                e.innerHTML = [(new Date()).toString(), ' ' + text].join(':');
+                container.insertBefore(e, container.firstChild);
+            }
+
+            btn.addEventListener('click', async function (event) {
+                event.preventDefault();
+                const result = await centrifuge.rpc('click', {});
+                drawText("Got channel: " + result.data.channel);
+
+                const channel = result.data.channel;
+                const sub = centrifuge.newSubscription(channel, {
+                    token: result.data.token,
+                    since: {
+                        offset: 0,
+                        epoch: ''
+                    }
+                });
+                sub.once("publication", function (ctx) {
+                    console.log(ctx.data);
+                    drawText("Got data: " + ctx.data.result);
+                    centrifuge.removeSubscription(sub);
+                }).subscribe();
+            });
+        });
+    </script>
+</head>
+
+<body>
+    <button id="btn">Click me for async action</button>
+    <div id="messages"></div>
+</body>
+
+</html>

--- a/v4/go_async_processing/main.go
+++ b/v4/go_async_processing/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"math/rand"
+	"net/http"
+	"time"
+
+	_ "net/http/pprof"
+
+	"github.com/centrifugal/gocent/v3"
+	"github.com/golang-jwt/jwt"
+	"github.com/google/uuid"
+)
+
+func handleConnect(w http.ResponseWriter, r *http.Request) {
+	resp := map[string]any{
+		"result": map[string]any{
+			"user": "test",
+		},
+	}
+
+	jsonData, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonData)
+}
+
+func handleRPC(w http.ResponseWriter, r *http.Request) {
+	uniqueChannel := uuid.NewString()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"sub":     "test",
+		"channel": uniqueChannel,
+		"exp":     time.Now().Unix() + 60,
+	})
+	tokenString, err := token.SignedString([]byte("keep-it-secret"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp := map[string]any{
+		"result": map[string]any{
+			"data": map[string]any{
+				"channel": uniqueChannel,
+				"token":   tokenString,
+			},
+		},
+	}
+
+	jsonData, _ := json.Marshal(resp)
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(jsonData)
+
+	go func() {
+		time.Sleep(time.Duration(rand.Intn(3000)) * time.Millisecond)
+		cent := gocent.New(gocent.Config{
+			Addr: "http://localhost:8000/api",
+		})
+		_, err := cent.Publish(context.Background(), uniqueChannel, []byte(`{"result": "result from `+uniqueChannel+`"}`))
+		if err != nil {
+			log.Printf("Error calling publish: %v", err)
+		}
+	}()
+}
+
+func main() {
+	http.Handle("/", http.FileServer(http.Dir("./")))
+	http.HandleFunc("/rpc", handleRPC)
+	http.HandleFunc("/connect", handleConnect)
+
+	if err := http.ListenAndServe(":3000", nil); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/v4/go_async_processing/main.go
+++ b/v4/go_async_processing/main.go
@@ -8,8 +8,6 @@ import (
 	"net/http"
 	"time"
 
-	_ "net/http/pprof"
-
 	"github.com/centrifugal/gocent/v3"
 	"github.com/golang-jwt/jwt"
 	"github.com/google/uuid"
@@ -54,9 +52,14 @@ func handleRPC(w http.ResponseWriter, r *http.Request) {
 	w.Write(jsonData)
 
 	go func() {
+		// Sleep for random time emulating long work.
 		time.Sleep(time.Duration(rand.Intn(3000)) * time.Millisecond)
+
+		// Then publish to Centrifugo channel.
+		// TODO: Centrifugo API client must be initialized once on start.
 		cent := gocent.New(gocent.Config{
 			Addr: "http://localhost:8000/api",
+			Key:  "keep-it-secret",
 		})
 		_, err := cent.Publish(context.Background(), uniqueChannel, []byte(`{"result": "result from `+uniqueChannel+`"}`))
 		if err != nil {

--- a/v4/go_async_processing/readme.md
+++ b/v4/go_async_processing/readme.md
@@ -5,7 +5,7 @@ A concept how to consume async request results from the backend using Centrifugo
 3. Client subscribes to a channel and waits for incoming message. It does this with recovery - so that message in channel is guaranteed to be received as soon as it was published to Centrifugo channel (thus avoiding races between publish and subscribe). 
 4. Client unsuscribes from a channel upon getting result to free resources
 
-Looks like we should make `history_meta_ttl` configurable per namespace in the future, for now `history_meta_ttl` sets a global history meta information expiration time - i.e. for all namespaces.
+In Centrifugo v4 `history_meta_ttl` sets a global history meta information expiration time - i.e. for all namespaces. Probably in the future releases we will let configure `history_meta_ttl` per channel namespace.
 
 Run example
 ===========

--- a/v4/go_async_processing/readme.md
+++ b/v4/go_async_processing/readme.md
@@ -1,0 +1,25 @@
+A concept how to consume async request results from the backend using Centrifugo (using Centrifugo subscriptions and history with recovery). We can initiate long work, return unique channel to consume from, then unsubscribe from it upon receiving the result of operation.
+
+1. Client sends RPC to the server (may be a simple AJAX request to the backend)
+2. Backend generates unique channel and returns it to a client together with subscription token
+3. Client subscribes to a channel and waits for incoming message. It does this with recovery - so that message in channel is guaranteed to be received as soon as it was published to Centrifugo channel (thus avoiding races between publish and subscribe). 
+4. Client unsuscribes from a channel upon getting result to free resources
+
+Looks like we should make `history_meta_ttl` configurable per namespace in the future, for now `history_meta_ttl` sets a global history meta information expiration time - i.e. for all namespaces.
+
+Run example
+===========
+
+Run Centrifugo with `config.json` provided here:
+
+```
+./centrifugo -c config.json
+```
+
+Run Go example:
+
+```
+go run main.go
+```
+
+Open http://localhost:3000


### PR DESCRIPTION
An interesting approach on how to consume async request results from the backend using Centrifugo (using Centrifugo subscriptions and history with recovery). We can initiate long work, return unique channel to consume from, then unsubscribe from it upon receiving the result of operation.

1. Client sends RPC to the server (may be a simple AJAX request to the backend)
2. Backend generates unique channel and returns it to a client together with subscription token
3. Client subscribes to a channel and waits for incoming message. It does this with recovery - so that message in channel is guaranteed to be received as soon as it was published to Centrifugo channel (thus avoiding races between publish and subscribe). 
4. Client unsuscribes from a channel upon getting result to free resources

Looks like we should make `history_meta_ttl` configurable per namespace in the future, for now `history_meta_ttl` sets a global history meta information expiration time - i.e. for all namespaces.  